### PR TITLE
Bug/memory fixes

### DIFF
--- a/common.h
+++ b/common.h
@@ -47,7 +47,6 @@
 #	define	UNUSED
 #endif
 
-#define DEBUG
 #ifdef DEBUG
 #	include <assert.h>
 #	define	ASSERT(expr)	do {if (!(expr)) {printf("%s:%s:%d - '%s' failed!\n", __FILE__, __FUNCTION__, __LINE__, #expr); abort();} }while(0)
@@ -89,9 +88,17 @@ void memfree(void* addr) {
     printf("free %p\n", addr);
     PyMem_Free(addr);
 }
+
+void *memcalloc(size_t nmemb, size_t size) {
+    void* addr = PyMem_Calloc(nmemb, size);
+    printf("calloc %p %u\n", addr, nmemb*size);
+    return addr;
+}
+
 #else
 #   define memalloc PyMem_Malloc
 #   define memfree  PyMem_Free
+#   define memcalloc PyMem_Calloc
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/common.h
+++ b/common.h
@@ -90,7 +90,12 @@ void memfree(void* addr) {
 }
 
 void *memcalloc(size_t nmemb, size_t size) {
+#   if PY_VERSION_HEX >=  0x03050000
     void* addr = PyMem_Calloc(nmemb, size);
+#   else
+    void *addr = memalloc(nmemb*size);
+    memset(addr, 0, nmemb*size);
+#   endif
     printf("calloc %p %u\n", addr, nmemb*size);
     return addr;
 }
@@ -98,7 +103,9 @@ void *memcalloc(size_t nmemb, size_t size) {
 #else
 #   define memalloc PyMem_Malloc
 #   define memfree  PyMem_Free
-#   define memcalloc PyMem_Calloc
+#   if PY_VERSION_HEX >=  0x03050000
+#   define memcalloc	PyMem_Calloc
+#   endif
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/dawg.c
+++ b/dawg.c
@@ -409,7 +409,12 @@ DAWG_clear(DAWG* dawg) {
 	// Delete all nodes
 	DAWGStatistics stats;
 	DAWG_get_stats(dawg, &stats);
+#if PY_VERSION_HEX >= 0x03050000
         DAWGNode **aux_nodelist = memcalloc(stats.nodes_count, sizeof(DAWGNode *));
+#else
+        DAWGNode **aux_nodelist = memalloc(stats.nodes_count*sizeof(DAWGNode *));
+	memset(aux_nodelist, 0, stats.nodes_count*sizeof(DAWGNode *));
+#endif
 	if(dawg->q0)
 	  DAWG_clear_recurse(dawg->q0, aux_nodelist);
 	memfree(aux_nodelist);

--- a/dawg.c
+++ b/dawg.c
@@ -379,7 +379,8 @@ static void
 DAWG_clear_recurse(DAWGNode* node, DAWGNode** nodelist) {
 
 	// Traverse all child nodes
-	for (size_t i=0; i < node->n; i++) {
+	size_t i;
+	for (i=0; i < node->n; i++) {
 		int done = 0;
 		DAWGNode *child = node->next[i].child;
 		// see if we've already freed this node

--- a/dawg.c
+++ b/dawg.c
@@ -119,7 +119,7 @@ DAWG_add_word_unchecked(DAWG* dawg, String word) {
 	if (i < dawg->prev_word.length)
 		DAWG_replace_or_register(dawg, state, dawg->prev_word, i);
 
-	// 3. add sufix
+	// 3. add suffix
 	while (i < word.length) {
 		DAWGNode* new = dawgnode_new();
 		if (new == NULL)
@@ -130,7 +130,7 @@ DAWG_add_word_unchecked(DAWG* dawg, String word) {
 		dawgnode_set_child(state, word.chars[i], new);
 
 		if (item) {
-			memfree(item);
+			HASH_FREE(item);
 			resize_hash(&dawg->reg);
 			hashtable_add(&dawg->reg, state);
 		}
@@ -245,7 +245,7 @@ DAWG_replace_or_register(DAWG* dawg, DAWGNode* state, String string, const size_
 				dawgnode_free(item->child);
 
 				if (prev) {
-					memfree(prev);
+					HASH_FREE(prev);
 					resize_hash(&dawg->reg);
 					hashtable_add(&dawg->reg, item->parent);
 				}
@@ -276,7 +276,7 @@ static bool PURE
 dawgnode_equivalence(DAWGNode* p, DAWGNode* q) {
 	/*
 		Both states p and q are equivalent (subtrees
-		rooted at p and q forms same languages):
+		rooted at p and q form same languages):
 
 		1. both are final/non-final
 		2. has same number of children
@@ -375,20 +375,46 @@ dawgnode_hash(const DAWGNode* p) {
 }
 
 
-int
-DAWG_clear_aux(DAWGNode* node, UNUSED const size_t depth, UNUSED void* extra) {
+static void
+DAWG_clear_recurse(DAWGNode* node, DAWGNode** nodelist) {
+
+	// Traverse all child nodes
+	for (size_t i=0; i < node->n; i++) {
+		int done = 0;
+		DAWGNode *child = node->next[i].child;
+		// see if we've already freed this node
+		DAWGNode **p;
+		for (p=nodelist; *p!=0; p++)
+		if (*p == child) {
+			done = 1;
+			break;
+		}
+		// If not, add it to the list and recurse over it
+		if (!done) {
+			*p = child;
+			DAWG_clear_recurse(child, nodelist);
+		}
+	}
+
+	// free the node
 	if (node->next)
 		memfree(node->next);
 
 	memfree(node);
-	return 1;
 }
 
 
 static int
 DAWG_clear(DAWG* dawg) {
-	DAWG_traverse_DFS_once(dawg, DAWG_clear_aux, NULL);
+	// Delete all nodes
+	DAWGStatistics stats;
+	DAWG_get_stats(dawg, &stats);
+        DAWGNode **aux_nodelist = memcalloc(stats.nodes_count, sizeof(DAWGNode *));
+	if(dawg->q0)
+	  DAWG_clear_recurse(dawg->q0, aux_nodelist);
+	memfree(aux_nodelist);
 
+	// Clear the main structure
 	dawg->q0	= NULL;
 	dawg->count	= 0;
 	dawg->state	= EMPTY;
@@ -469,7 +495,7 @@ DAWG_traverse_DFS_once(DAWG* dawg, DAWG_traverse_callback callback, void* extra)
 	if (dawg->q0) {
 		if (dawg->visited_marker == 0) {
 			// counter wrapped, visited fields have to be cleared
-			puts("cleared");
+			//puts("cleared");
 			DAWG_traverse_clear_visited(dawg->q0);
 			dawg->visited_marker += 1;
 		}

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ module = Extension(
 	'pydawg',
 	sources = ['pydawg.c'],
 	define_macros = [
+		('DEBUG', 1),	# define debug mode
 		('DAWG_PERFECT_HASHING', ''),	# enable perfect hashing
 		('DAWG_UNICODE', ''),			# use unicode
 	],


### PR DESCRIPTION
 fixed memory problems
 * use `HASH_FREE` macro (defined as `free` in `dawg.h`) for memory that was allocated with `HASH_ALLOC` (using `malloc`) inside `hash/hashtable.c`
 * fixed `DAWG_clear()`: can't use `DAWG_traverse_DFS_once()` for memory free, since the same node could be reached more than once (and when checking if it had been visited, we could then be accessing a node that has already been freed, hence behaviour would be unpredictable)

minor changes:
 * commented out `puts()` line
 * `DEBUG` definition moved to `setup.py` file

The second problem has been verified by running _valgrind_ on a pyDAWG version compiled against a debug Python. This is the final excerpt of _valgrind's_ output:

```
==18427== Invalid read of size 8
==18427==    at 0x6F03BAF: DAWG_traverse_DFS_once_aux (dawg.c:454)
==18427==    by 0x6F03BC5: DAWG_traverse_DFS_once_aux (dawg.c:454)
==18427==    by 0x6F03BC5: DAWG_traverse_DFS_once_aux (dawg.c:454)
==18427==    by 0x6F03BC5: DAWG_traverse_DFS_once_aux (dawg.c:454)
==18427==    by 0x6F03CB7: DAWG_traverse_DFS_once (dawg.c:477)
==18427==    by 0x6F04530: DAWG_clear (dawg.c:390)
==18427==    by 0x6F045DB: DAWG_free (dawg.c:42)
==18427==    by 0x6F045F8: dawgobj_del (DAWG_class.c:61)
==18427==    by 0x4A172E: _Py_Dealloc (object.c:1786)
==18427==    by 0x48F4C1: dict_dealloc (dictobject.c:2014)
==18427==    by 0x4A172E: _Py_Dealloc (object.c:1786)
==18427==    by 0x4B289D: subtype_dealloc (typeobject.c:1207)
==18427==  Address 0xdbdbdbdbdbdbdbe3 is not stack'd, malloc'd or (recently) free'd
==18427== 
==18427== 
==18427== Process terminating with default action of signal 11 (SIGSEGV)
==18427==  General Protection Fault
==18427==    at 0x6F03BAF: DAWG_traverse_DFS_once_aux (dawg.c:454)
==18427==    by 0x6F03BC5: DAWG_traverse_DFS_once_aux (dawg.c:454)
==18427==    by 0x6F03BC5: DAWG_traverse_DFS_once_aux (dawg.c:454)
==18427==    by 0x6F03BC5: DAWG_traverse_DFS_once_aux (dawg.c:454)
==18427==    by 0x6F03CB7: DAWG_traverse_DFS_once (dawg.c:477)
==18427==    by 0x6F04530: DAWG_clear (dawg.c:390)
==18427==    by 0x6F045DB: DAWG_free (dawg.c:42)
==18427==    by 0x6F045F8: dawgobj_del (DAWG_class.c:61)
==18427==    by 0x4A172E: _Py_Dealloc (object.c:1786)
==18427==    by 0x48F4C1: dict_dealloc (dictobject.c:2014)
==18427==    by 0x4A172E: _Py_Dealloc (object.c:1786)
==18427==    by 0x4B289D: subtype_dealloc (typeobject.c:1207)
```
so, the problem is accessing free memory. The proposed workaround is to construct a list of all the already freed nodes, and _before_ trying to visit a node, check if it's in the list, and avoid it if so. It adds some overhead but not much (and besides, this is only executed on object deallocation).