### PR TITLE
fix: word2index, improv: mem deallocation

### DIFF
--- a/DAWG_class.c
+++ b/DAWG_class.c
@@ -408,7 +408,11 @@ static PyObject*
 dawgmeth_clear(PyObject* self, UNUSED PyObject* args) {
 #define obj ((DAWGclass*)self)
 #define dawg (obj->dawg)
-	DAWG_clear(&dawg);
+	int result = DAWG_clear(&dawg);
+	if(result==DAWG_NO_MEM) {
+		PyErr_NoMemory();
+		return NULL;
+	}
 	obj->version += 1;
 	Py_RETURN_NONE;
 #undef dawg

--- a/common.h
+++ b/common.h
@@ -104,7 +104,13 @@ void *memcalloc(size_t nmemb, size_t size) {
 #   define memalloc PyMem_Malloc
 #   define memfree  PyMem_Free
 #   if PY_VERSION_HEX >=  0x03050000
-#   define memcalloc	PyMem_Calloc
+#     define memcalloc	PyMem_Calloc
+#   else
+      static inline void *memcalloc(size_t nmemb, size_t size) {
+	void *addr = memalloc(nmemb*size);
+	memset(addr, 0, nmemb*size);
+	return addr;
+      }
 #   endif
 #endif
 

--- a/dawg_mph.c
+++ b/dawg_mph.c
@@ -58,7 +58,7 @@ DAWG_mph_word2index(DAWG* dawg, const DAWG_LETTER_TYPE* word, const size_t wordl
 			return DAWG_NOT_EXISTS;
 	}
 
-	return index;
+	return state->eow ? index : DAWG_NOT_EXISTS;
 }
 
 

--- a/dawg_pickle.c
+++ b/dawg_pickle.c
@@ -423,7 +423,9 @@ DAWG_load(DAWG* dawg, uint8_t* array, size_t size) {
 		} // for
 	} // node
 
-	DAWG_clear(dawg);
+	result = DAWG_clear(dawg);
+	if(result==DAWG_NO_MEM)
+		goto error;
 	dawg->q0 = (state == EMPTY) ? NULL : id2node[root_id];
 	dawg->count	= words_count;
 	dawg->longest_word = longest_word;

--- a/unittests.py
+++ b/unittests.py
@@ -263,10 +263,18 @@ class TestMPH(TestDAWGBase):
 			self.assertEqual(min(S), 1)
 			self.assertEqual(max(S), len(D))
 
-			# inexising words
+			# unexisting words
 			index = D.word2index(conv("xyz"))
 			self.assertEqual(index, None)
 			index = D.word2index(conv(""))
+			self.assertEqual(index, None)
+
+			# Strings that are prefixes of existing words
+			# [1] a prefix not containing any valid word
+			index = D.word2index(conv("attrib"))
+			self.assertEqual(index, None)
+			# [2] a prefix that contains a valid word
+			index = D.word2index(conv("warb"))
 			self.assertEqual(index, None)
 
 


### PR DESCRIPTION
* improved object memory deallocation: the fix in https://github.com/WojciechMula/pyDAWG/pull/5 was too slow for big DAWGs (an object holding a million strings could take _minutes_ to deallocate, since for each node it traversed the whole list so far, to check if it was already there). This new version makes only two passes: first build the list of nodes using `DAWG_traverse_DFS_once()`, then deallocate all nodes in the list, and is almost instantaneous.

* bugfix in dawg_mph.c: `word2index()` for a string that 
      (a) is not a string in the DAWG 
      (b) is a prefix of an existing word and 
      (c) also contains a valid word, 
    should return `None` but returned the index of (c)

* implement `memcalloc()` for Python < 3.5 (which does not have `PyMem_Calloc`)
