### PR TITLE
Fix compile issue on mac

### DIFF
--- a/dawg.c
+++ b/dawg.c
@@ -17,7 +17,7 @@
 #include "dawg.h"
 #include <string.h>
 
-#include <malloc.h>
+#include <stdlib.h>
 
 
 static int


### PR DESCRIPTION
Standard malloc location is from stdlib.h.

---

To repro on mac:
```
$ python -V
Python 3.6.8 :: Anaconda, Inc.

$ uname -a
Darwin mbp-isi-joelb.local 20.6.0 Darwin Kernel Version 20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64 x86_64 i386 MacBookPro11,4 Darwin

$ python setup.py install
running install
running build
running build_ext
building 'pydawg' extension
creating build
creating build/temp.macosx-10.7-x86_64-3.6
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/joelb/anaconda3/include -arch x86_64 -I/Users/joelb/anaconda3/include -arch x86_64 -DDEBUG=1 -DDAWG_PERFECT_HASHING= -DDAWG_UNICODE= -I/Users/joelb/anaconda3/include/python3.6m -c pydawg.c -o build/temp.macosx-10.7-x86_64-3.6/pydawg.o
In file included from pydawg.c:22:
./dawg.c:20:10: fatal error: 'malloc.h' file not found
#include <malloc.h>
         ^~~~~~~~~~
1 error generated.
error: command 'gcc' failed with exit status 1
```